### PR TITLE
#41: typo in JsonObject.isNull javadoc

### DIFF
--- a/api/src/main/java/javax/json/JsonObject.java
+++ b/api/src/main/java/javax/json/JsonObject.java
@@ -263,7 +263,7 @@ public interface JsonObject extends JsonStructure, Map<String, JsonValue> {
      * {@code JsonValue.NULL}.
      *
      * @param name name whose associated value is checked
-     * @return return true if the associated value is {@code JsonValue.NUL},
+     * @return return true if the associated value is {@code JsonValue.NULL},
      * otherwise false
      * @throws NullPointerException if the specified name doesn't have any
      * mapping


### PR DESCRIPTION
fixing typo
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>