### PR TITLE
Scope.IN_FIELD is nod popped out after writing JsonValue of type number

### DIFF
--- a/impl/src/main/java/org/glassfish/json/JsonGeneratorImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonGeneratorImpl.java
@@ -293,6 +293,7 @@ class JsonGeneratorImpl implements JsonGenerator {
             case NUMBER:
                 JsonNumber number = (JsonNumber)value;
                 writeValue(number.toString());
+                popFieldContext();
                 break;
             case TRUE:
                 write(true);


### PR DESCRIPTION
Fixes #62 
Fixed popping context when write(JsonValue value) is invoked after writeKey(String key) on JsonGeneratorImpl with a json number passed as value in.