### PR TITLE
fixes #59: Add context info for JSON Patch test failure

### DIFF
--- a/impl/src/main/java/org/glassfish/json/JsonMessages.java
+++ b/impl/src/main/java/org/glassfish/json/JsonMessages.java
@@ -269,8 +269,8 @@ final class JsonMessages {
         return localize("patch.move.target.null", from);
     }
 
-    static String PATCH_TEST_FAILED() {
-        return localize("patch.test.failed");
+    static String PATCH_TEST_FAILED(String path, String value) {
+        return localize("patch.test.failed", path, value);
     }
 
     static String PATCH_ILLEGAL_OPERATION(String operation) {

--- a/impl/src/main/java/org/glassfish/json/JsonPatchImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPatchImpl.java
@@ -193,7 +193,7 @@ public class JsonPatchImpl implements JsonPatch {
                 return pointer.add(from.remove(target), from.getValue(target));
             case TEST:
                 if (! getValue(operation).equals(pointer.getValue(target))) {
-                    throw new JsonException(JsonMessages.PATCH_TEST_FAILED());
+                    throw new JsonException(JsonMessages.PATCH_TEST_FAILED(operation.getString("path"), getValue(operation).toString()));
                 }
                 return target;
             default:

--- a/impl/src/main/resources/org/glassfish/json/messages.properties
+++ b/impl/src/main/resources/org/glassfish/json/messages.properties
@@ -107,6 +107,6 @@ noderef.array.index.err=An array item index is out of range. Index: {0}, Size: {
 patch.must.be.array=A JSON Patch must be an array of JSON Objects
 patch.move.proper.prefix=The ''{0}'' path of the patch operation ''move'' is a proper prefix of the ''{1}'' path
 patch.move.target.null=The ''{0}'' path of the patch operation ''move'' does not exist in target object
-patch.test.failed=The JSON Patch operation ''test'' failed
+patch.test.failed=The JSON Patch operation ''test'' failed for path ''{0}'' and value ''{1}''
 patch.illegal.operation=Illegal value for the op member of the JSON Patch operation: ''{0}''
 patch.member.missing=The JSON Patch operation ''{0}'' must contain a ''{1}'' member


### PR DESCRIPTION
adds additional info to the exception message 