### PR TITLE
Cache JsonProvider.provider() result as per javadoc recommendation

### DIFF
--- a/api/src/main/java/javax/json/Json.java
+++ b/api/src/main/java/javax/json/Json.java
@@ -81,7 +81,8 @@ import javax.json.stream.JsonParserFactory;
  * threads.
  */
 public final class Json {
-
+	static final JsonProvider PROVIDER = JsonProvider.provider();
+	
     private Json() {
     }
 
@@ -92,7 +93,7 @@ public final class Json {
      * @return a JSON parser
      */
     public static JsonParser createParser(Reader reader) {
-        return JsonProvider.provider().createParser(reader);
+        return PROVIDER.createParser(reader);
     }
 
     /**
@@ -106,7 +107,7 @@ public final class Json {
      * @return a JSON parser
      */
     public static JsonParser createParser(InputStream in) {
-        return JsonProvider.provider().createParser(in);
+        return PROVIDER.createParser(in);
     }
 
     /**
@@ -116,7 +117,7 @@ public final class Json {
      * @return a JSON generator
      */
     public static JsonGenerator createGenerator(Writer writer) {
-        return JsonProvider.provider().createGenerator(writer);
+        return PROVIDER.createGenerator(writer);
     }
 
     /**
@@ -126,7 +127,7 @@ public final class Json {
      * @return a JSON generator
      */
     public static JsonGenerator createGenerator(OutputStream out) {
-        return JsonProvider.provider().createGenerator(out);
+        return PROVIDER.createGenerator(out);
     }
 
     /**
@@ -135,7 +136,7 @@ public final class Json {
      * @return JSON parser factory.
      *
     public static JsonParserFactory createParserFactory() {
-        return JsonProvider.provider().createParserFactory();
+        return PROVIDER.createParserFactory();
     }
      */
 
@@ -150,7 +151,7 @@ public final class Json {
      * @return JSON parser factory
      */
     public static JsonParserFactory createParserFactory(Map<String, ?> config) {
-        return JsonProvider.provider().createParserFactory(config);
+        return PROVIDER.createParserFactory(config);
     }
 
     /**
@@ -159,7 +160,7 @@ public final class Json {
      * @return JSON generator factory
      *
     public static JsonGeneratorFactory createGeneratorFactory() {
-        return JsonProvider.provider().createGeneratorFactory();
+        return PROVIDER.createGeneratorFactory();
     }
     */
 
@@ -175,7 +176,7 @@ public final class Json {
      */
     public static JsonGeneratorFactory createGeneratorFactory(
             Map<String, ?> config) {
-        return JsonProvider.provider().createGeneratorFactory(config);
+        return PROVIDER.createGeneratorFactory(config);
     }
 
     /**
@@ -187,7 +188,7 @@ public final class Json {
      * @return a JSON writer
      */
     public static JsonWriter createWriter(Writer writer) {
-        return JsonProvider.provider().createWriter(writer);
+        return PROVIDER.createWriter(writer);
     }
 
     /**
@@ -200,7 +201,7 @@ public final class Json {
      * @return a JSON writer
      */
     public static JsonWriter createWriter(OutputStream out) {
-        return JsonProvider.provider().createWriter(out);
+        return PROVIDER.createWriter(out);
     }
 
     /**
@@ -210,7 +211,7 @@ public final class Json {
      * @return a JSON reader
      */
     public static JsonReader createReader(Reader reader) {
-        return JsonProvider.provider().createReader(reader);
+        return PROVIDER.createReader(reader);
     }
 
     /**
@@ -222,7 +223,7 @@ public final class Json {
      * @return a JSON reader
      */
     public static JsonReader createReader(InputStream in) {
-        return JsonProvider.provider().createReader(in);
+        return PROVIDER.createReader(in);
     }
 
     /**
@@ -236,7 +237,7 @@ public final class Json {
      * @return a JSON reader factory
      */
     public static JsonReaderFactory createReaderFactory(Map<String, ?> config) {
-        return JsonProvider.provider().createReaderFactory(config);
+        return PROVIDER.createReaderFactory(config);
     }
 
     /**
@@ -250,7 +251,7 @@ public final class Json {
      * @return a JSON writer factory
      */
     public static JsonWriterFactory createWriterFactory(Map<String, ?> config) {
-        return JsonProvider.provider().createWriterFactory(config);
+        return PROVIDER.createWriterFactory(config);
     }
 
     /**
@@ -259,7 +260,7 @@ public final class Json {
      * @return a JSON array builder
      */
     public static JsonArrayBuilder createArrayBuilder() {
-        return JsonProvider.provider().createArrayBuilder();
+        return PROVIDER.createArrayBuilder();
     }
 
     /**
@@ -271,7 +272,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonArrayBuilder createArrayBuilder(JsonArray array) {
-        return JsonProvider.provider().createArrayBuilder(array);
+        return PROVIDER.createArrayBuilder(array);
     }
 
     /**
@@ -287,7 +288,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonArrayBuilder createArrayBuilder(Collection<?> collection) {
-        return JsonProvider.provider().createArrayBuilder(collection);
+        return PROVIDER.createArrayBuilder(collection);
     }
 
     /**
@@ -296,7 +297,7 @@ public final class Json {
      * @return a JSON object builder
      */
     public static JsonObjectBuilder createObjectBuilder() {
-        return JsonProvider.provider().createObjectBuilder();
+        return PROVIDER.createObjectBuilder();
     }
 
     /**
@@ -308,7 +309,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonObjectBuilder createObjectBuilder(JsonObject object) {
-        return JsonProvider.provider().createObjectBuilder(object);
+        return PROVIDER.createObjectBuilder(object);
     }
 
     /**
@@ -324,7 +325,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonObjectBuilder createObjectBuilder(Map<String, Object> map) {
-        return JsonProvider.provider().createObjectBuilder(map);
+        return PROVIDER.createObjectBuilder(map);
     }
 
     /**
@@ -343,7 +344,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPointer createPointer(String jsonPointer) {
-        return JsonProvider.provider().createPointer(jsonPointer);
+        return PROVIDER.createPointer(jsonPointer);
     }
 
     /**
@@ -354,7 +355,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPatchBuilder createPatchBuilder() {
-        return JsonProvider.provider().createPatchBuilder();
+        return PROVIDER.createPatchBuilder();
     }
 
     /**
@@ -368,7 +369,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPatchBuilder createPatchBuilder(JsonArray array) {
-        return JsonProvider.provider().createPatchBuilder(array);
+        return PROVIDER.createPatchBuilder(array);
     }
 
     /**
@@ -381,7 +382,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPatch createPatch(JsonArray array) {
-        return JsonProvider.provider().createPatch(array);
+        return PROVIDER.createPatch(array);
     }
 
     /**
@@ -396,7 +397,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPatch createDiff(JsonStructure source, JsonStructure target) {
-        return JsonProvider.provider().createDiff(source, target);
+        return PROVIDER.createDiff(source, target);
     }
 
     /**
@@ -409,7 +410,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonMergePatch createMergePatch(JsonValue patch) {
-        return JsonProvider.provider().createMergePatch(patch);
+        return PROVIDER.createMergePatch(patch);
     }
 
     /**
@@ -424,7 +425,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonMergePatch createMergeDiff(JsonValue source, JsonValue target) {
-        return JsonProvider.provider().createMergeDiff(source, target);
+        return PROVIDER.createMergeDiff(source, target);
     }
 
     /**
@@ -440,7 +441,7 @@ public final class Json {
      */
     public static JsonBuilderFactory createBuilderFactory(
             Map<String, ?> config) {
-        return JsonProvider.provider().createBuilderFactory(config);
+        return PROVIDER.createBuilderFactory(config);
     }
 
     /**
@@ -452,7 +453,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonString createValue(String value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -464,7 +465,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(int value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -476,7 +477,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(long value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -488,7 +489,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(double value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -500,7 +501,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(BigDecimal value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -512,7 +513,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(BigInteger value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**


### PR DESCRIPTION
I got through this because I found a performance hostpot in calling Json methods (about 500 microsec per call on a i5) 